### PR TITLE
Update mysql server to be able to connect to new AWS database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 apikeys.txt
 alma-key.txt
 msq-permissions.txt
+certs
 
 venv
 .venv

--- a/gbif_dbtools.py
+++ b/gbif_dbtools.py
@@ -1,5 +1,3 @@
-from itertools import zip_longest
-
 import pymysql
 
 

--- a/gbif_dbtools.py
+++ b/gbif_dbtools.py
@@ -1,3 +1,5 @@
+from itertools import zip_longest
+
 import pymysql
 
 
@@ -7,8 +9,27 @@ def query_db(sql):
     :param sql: String script to run
     :return: Cursor
     """
-    host, user, password, database = get_keys('msq-permissions.txt')
-    with pymysql.connect(host=host, user=user, password=password, db=database) as db:
+    args = get_keys('msq-permissions.txt')
+    if len(args) == 4:
+        # old style permissions format with host, user, password, db
+        db = pymysql.connect(host=args[0], user=args[1], password=args[2], db=args[3])
+    elif len(args) == 8:
+        # new style permissions with addition of port and ssl config
+        db = pymysql.connect(
+            host=args[0],
+            port=int(args[1]),
+            user=args[2],
+            password=args[3],
+            db=args[4],
+            ssl_ca=args[5],
+            ssl_key=args[6],
+            ssl_cert=args[7],
+        )
+    else:
+        print('Permissions file must have 5 or 7 args specified')
+        exit(1)
+
+    with db:
         cursor = db.cursor()
         try:
             cursor.execute(sql)


### PR DESCRIPTION
The new AWS database requires connections to be over SSL which this change facilitates. It is however backwards compatible so all that needs to be changed to connect to the new database is a change to the `msq-permissions.txt` file.

This means creds for the database can be provided in two ways using the `msq-permissions.txt` file:

The 4 line current format:
```
{host}
{user}
{password}
{database}
```

The 8 line new format:
```
{host}
{port}
{user}
{password}
{database}
{SSL CA relative or full path}
{SSL client key relative or full path}
{SSL client certficate relative or full path}
```

It is advised that certificates are stored in the gitignored `certs` directory.